### PR TITLE
Throws an error if there are missing elements in menuItem

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,14 @@ module.exports = function (menuElement, options) {
     options.menuItemSubMenuSelector || '.menu-aim__item-submenu'
   var delayingClassName = options.delayingClassName || 'menu-aim--delaying'
 
+  if (!menuElement.querySelector(menuItemSelector)) {
+    throw new Error('No `menuItemSelector` element given')
+  }
+
+  if (!menuElement.querySelector(menuItemSubMenuSelector)) {
+    throw new Error('No `menuItemSubMenuSelector` element given')
+  }
+
   var previousMouseCoordinates = {}
   var currentMouseCoordinates = {}
   var timeoutId


### PR DESCRIPTION
Hey there thanks for the great repo. 
I thought it might be usefull to throw an error if there are missing elements like the `menuItemSelector` or `menuItemSubMenuSelector`